### PR TITLE
Ref: Remove Estimate Time From DepartureSchedule

### DIFF
--- a/Jaketi/Features/Models/TrainStation.swift
+++ b/Jaketi/Features/Models/TrainStation.swift
@@ -37,16 +37,12 @@ struct TrainStation: Hashable, Decodable {
     struct DepartureSchedule: Hashable {
         var id: UUID = UUID()
         var timeDeparture: Date
-        var estimateTimeInMinute: Int
         var destinationStation: DestinationType
         var isWeekend: Bool = false
         
         init(timeDeparture: Date, destinationStation: DestinationType, isWeekend: Bool) {
-            let viewModel = TrainStationViewModel()
-            
             self.id = UUID()
             self.timeDeparture = timeDeparture
-            self.estimateTimeInMinute = viewModel.getTimeDifferenceInMinute(timeDeparture)
             self.destinationStation = destinationStation
             self.isWeekend = isWeekend
         }

--- a/Jaketi/Features/Presenters/Components/ScheduleList.swift
+++ b/Jaketi/Features/Presenters/Components/ScheduleList.swift
@@ -32,10 +32,9 @@ struct ScheduleList: View {
                 ForEach(departureSchedules, id: \.self) { schedule in
                     ScheduleRow(
                         timeDeparture: schedule.timeDeparture,
-                        destination: schedule.destinationStation,
+                        destination: schedule.destinationStation
                         // TODO: uncomment once it's fixed
-                        // stops: 6,
-                        estimateTimeInMinute: schedule.estimateTimeInMinute
+                        // stops: 6
                     )
                 }
             } else {

--- a/Jaketi/Features/Presenters/Components/ScheduleRow.swift
+++ b/Jaketi/Features/Presenters/Components/ScheduleRow.swift
@@ -13,17 +13,18 @@ struct ScheduleRow: View {
     public var destination: DestinationType
     // TODO: uncomment once it's fixed
     // public var stops: Int
-    public var estimateTimeInMinute: Int
     
+    private var estimateTimeInMinute: Int = 0
     private let isArrived: Bool
     
-    init(timeDeparture: Date, destination: DestinationType, estimateTimeInMinute: Int) {
+    init(timeDeparture: Date, destination: DestinationType) {
+        let viewModel = TrainStationViewModel()
+        
         self.timeDeparture = timeDeparture
         self.destination = destination
         // TODO: uncomment once it's fixed
         // self.stops = stops
-        self.estimateTimeInMinute = estimateTimeInMinute
-        
+        self.estimateTimeInMinute = viewModel.getTimeDifferenceInMinute(timeDeparture)
         self.isArrived = estimateTimeInMinute <= 0
     }
     
@@ -89,10 +90,9 @@ struct ScheduleRow_Previews: PreviewProvider {
     static var previews: some View {
         ScheduleRow(
             timeDeparture: Date.now,
-            destination: DestinationType.bundaranHI,
+            destination: DestinationType.bundaranHI
             // TODO: uncomment once it's fixed
             // stops: 6,
-            estimateTimeInMinute: 1
         )
     }
 }


### PR DESCRIPTION
## Description

Remove Estimate Time From DepartureSchedule since the data should be dynamic.

We move the calculation to the `ScheduleRow` component